### PR TITLE
Add RequireAuth guard for drive route

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-d
 import LandingPage from "@/pages/LandingPage"
 import SignIn from "@/pages/SignIn"
 import DriveView from "@/pages/DriveView"
+import RequireAuth from "@/components/RequireAuth"
 
 export default function App() {
   return (
@@ -18,7 +19,14 @@ export default function App() {
         <Route path="/drive" element={<Navigate to="/drive/root" replace />} />
 
         {/* Drive - nested folders */}
-        <Route path="/drive/:folderId/*" element={<DriveView />} />
+        <Route
+          path="/drive/:folderId/*"
+          element={
+            <RequireAuth>
+              <DriveView />
+            </RequireAuth>
+          }
+        />
 
         {/* Catch-all → home */}
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/components/RequireAuth.tsx
+++ b/frontend/src/components/RequireAuth.tsx
@@ -1,0 +1,13 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "@/hooks/useAuth";
+import type React from "react";
+
+export default function RequireAuth({ children }: { children: React.ReactElement }) {
+  const { session } = useAuth();
+
+  if (!session) {
+    return <Navigate to="/signin" />;
+  }
+
+  return children;
+}


### PR DESCRIPTION
## Summary
- add `RequireAuth` component to redirect unauthenticated users to `/signin`
- wrap drive route with auth guard in `App.tsx`

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_6846a8c71e2083319773811ecf1c16c4