### PR TITLE
Fix upload refresh

### DIFF
--- a/frontend/src/components/UploadButton.tsx
+++ b/frontend/src/components/UploadButton.tsx
@@ -5,9 +5,10 @@ import { useUpload } from '@/hooks/useUpload'
 
 export interface UploadButtonProps {
   parentId: number
+  onUploaded?: () => void
 }
 
-export default function UploadButton({ parentId }: UploadButtonProps) {
+export default function UploadButton({ parentId, onUploaded }: UploadButtonProps) {
   const inputRef = useRef<HTMLInputElement>(null)
   const { uploadFile } = useUpload()
 
@@ -16,6 +17,7 @@ export default function UploadButton({ parentId }: UploadButtonProps) {
     if (file) {
       await uploadFile(file, parentId)
       e.target.value = ''
+      onUploaded?.()
     }
   }
 

--- a/frontend/src/hooks/useFiles.ts
+++ b/frontend/src/hooks/useFiles.ts
@@ -5,15 +5,19 @@ export function useFiles(parentId: number) {
   const { session } = useAuth();
   const [files, setFiles] = useState<any[]>([]);
 
-  useEffect(() => {
+  const fetchFiles = async () => {
     if (!session) return;
     const token = session.access_token;
-    fetch(`/api/files/${parentId}`, {
+    const res = await fetch(`/api/files/${parentId}`, {
       headers: { Authorization: `Bearer ${token}` }
-    })
-      .then(res => res.json())
-      .then(setFiles);
+    });
+    const data = await res.json();
+    setFiles(data);
+  };
+
+  useEffect(() => {
+    fetchFiles();
   }, [parentId, session]);
 
-  return files;
+  return { files, refetch: fetchFiles };
 }

--- a/frontend/src/pages/DriveView.tsx
+++ b/frontend/src/pages/DriveView.tsx
@@ -2,13 +2,11 @@
 
 import { useState, useEffect } from "react"
 import { useParams, useNavigate, useLocation } from "react-router-dom"
-import Navbar from "@/components/Navbar"
 import FolderCard from "@/components/FolderCard"
 import FileCard from "@/components/FileCard"
 import UploadButton from "@/components/UploadButton"
 import { useFolders } from "@/hooks/useFolders"
 import { useFiles } from "@/hooks/useFiles"
-import { useUpload } from "@/hooks/useUpload"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -51,11 +49,10 @@ export default function DriveView() {
   const navigate = useNavigate()
   const location = useLocation()
 
-  const parentId = folderId === "root" ? null : Number(folderId)
+  const currentFolderId = folderId === "root" ? 0 : Number(folderId)
 
-  const folders = useFolders(parentId)
-  const files = useFiles(parentId ?? 0)
-  useUpload()
+  const folders = useFolders(currentFolderId === 0 ? null : currentFolderId)
+  const { files, refetch } = useFiles(currentFolderId)
 
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid")
   const [searchQuery, setSearchQuery] = useState("")
@@ -125,7 +122,7 @@ export default function DriveView() {
                 <Grid3X3 className="w-8 h-8" />
               )}
             </Button>
-            <UploadButton parentId={parentId ?? 0} />
+            <UploadButton parentId={currentFolderId} onUploaded={refetch} />
             <Button 
               variant="default" 
               onClick={signOut} 


### PR DESCRIPTION
## Summary
- add optional `onUploaded` callback to `UploadButton`
- add `refetch` helper to `useFiles`
- refresh files after uploading in `DriveView`
- remove unused `Navbar` import

## Testing
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6846b795c4c88331a6d2756e376245f6