### PR TITLE
chore: centralize supabase clients

### DIFF
--- a/backend/src/controllers/auth.ts
+++ b/backend/src/controllers/auth.ts
@@ -1,7 +1,7 @@
-import { supabaseClient } from '@/services/supabase';
+import { supabase } from '@/services/supabase';
 
 export async function verifySession(accessToken: string) {
-  const { data, error } = await supabaseClient.auth.getUser(accessToken);
+  const { data, error } = await supabase.auth.getUser(accessToken);
   if (error || !data.user) {
     throw new Error('Invalid session');
   }

--- a/backend/src/services/supabase.ts
+++ b/backend/src/services/supabase.ts
@@ -6,4 +6,4 @@ import {
 } from '@/config/env';
 
 export const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
-export const supabaseClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);

--- a/backend/src/services/supabaseAdmin.ts
+++ b/backend/src/services/supabaseAdmin.ts
@@ -1,8 +1,0 @@
-// src/lib/supabaseAdmin.ts
-import { createClient } from "@supabase/supabase-js";
-import "dotenv/config";
-
-const url        = process.env.VITE_SUPABASE_URL!;
-const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-
-export const supabaseAdmin = createClient(url, serviceKey);

--- a/backend/src/utils/test-db.ts
+++ b/backend/src/utils/test-db.ts
@@ -1,27 +1,13 @@
-// src/scripts/test-db.ts
-import "dotenv/config";
-import { createClient } from "@supabase/supabase-js";
-
-const url        = process.env.VITE_SUPABASE_URL;
-const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-
-console.log("→ URL:", url);
-console.log("→ Service Key defined?:", !!serviceKey);
-
-if (!url || !serviceKey) {
-  console.error("❌ Missing one of VITE_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
-  process.exit(1);
-}
-
-const supabase = createClient(url, serviceKey);
+// src/utils/test-db.ts
+import { supabaseAdmin } from '@/services/supabase';
 
 async function main() {
-  const { data, error } = await supabase.from("folder").select("*");
+  const { data, error } = await supabaseAdmin.from('folder').select('*');
   if (error) {
-    console.error("❌ Supabase error:", error);
+    console.error('❌ Supabase error:', error);
     process.exit(1);
   }
-  console.log("✅ Success:", data);
+  console.log('✅ Success:', data);
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary
- consolidate Supabase admin and client creation into `services/supabase`
- remove standalone `supabaseAdmin` service and update imports
- simplify test script to reuse shared admin client

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c3d93235f08331ba120d7c1f63f021