### PR TITLE
Add PostHog analytics ingest proxy

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4,6 +4,7 @@ import cors from '@fastify/cors';
 import authRoutes from './routes/auth';
 import folderRoutes from './routes/folders';
 import fileRoutes from './routes/files';
+import analyticsRoutes from './routes/analytics';
 
 export const app = Fastify();
 
@@ -12,3 +13,4 @@ app.register(cors, { origin: true });
 app.register(authRoutes);
 app.register(folderRoutes);
 app.register(fileRoutes);
+app.register(analyticsRoutes);

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -5,6 +5,10 @@ export const SUPABASE_URL = process.env.VITE_SUPABASE_URL!;
 export const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY!;
 export const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
+export const POSTHOG_API_HOST =
+  process.env.POSTHOG_API_HOST || 'https://app.posthog.com';
+export const POSTHOG_API_KEY = process.env.POSTHOG_API_KEY || '';
+
 if (!DATABASE_URL || !SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
   throw new Error('Missing environment variables');
 }

--- a/backend/src/routes/analytics.ts
+++ b/backend/src/routes/analytics.ts
@@ -1,0 +1,17 @@
+import { FastifyInstance } from 'fastify';
+import { forwardToPostHog } from '@/services/analytics';
+
+console.log("Loading analytics.ts");
+
+export default async function (app: FastifyInstance) {
+  app.post('/ingest', async (request, reply) => {
+    const res = await forwardToPostHog(request.body);
+    const text = await res.text();
+    reply
+      .status(res.status)
+      .headers({
+        'content-type': res.headers.get('content-type') ?? 'application/json',
+      })
+      .send(text);
+  });
+}

--- a/backend/src/services/analytics.ts
+++ b/backend/src/services/analytics.ts
@@ -1,0 +1,14 @@
+import { POSTHOG_API_HOST, POSTHOG_API_KEY } from '@/config/env';
+
+const fetchFn: any = (globalThis as any).fetch;
+
+export async function forwardToPostHog(payload: unknown) {
+  return fetchFn(`${POSTHOG_API_HOST}/ingest`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(POSTHOG_API_KEY ? { Authorization: `Bearer ${POSTHOG_API_KEY}` } : {}),
+    },
+    body: typeof payload === 'string' ? payload : JSON.stringify(payload),
+  });
+}


### PR DESCRIPTION
## Summary
- forward analytics events to PostHog
- expose `/ingest` endpoint and register route

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68c3db2f7a908331b642baa09c383ee6