### PR TITLE
Add folder deletion and rename routes

### DIFF
--- a/backend/src/controllers/folders.ts
+++ b/backend/src/controllers/folders.ts
@@ -14,3 +14,34 @@ export function createFolder(args: {
 }) {
   return prisma.folder.create({ data: args });
 }
+
+export async function deleteFolder(id: number, ownerId: string) {
+  const folder = await prisma.folder.findUnique({ where: { id } });
+  if (!folder || folder.ownerId !== ownerId) {
+    throw new Error('Folder not found');
+  }
+
+  const children = await prisma.folder.findMany({
+    where: { parentId: id, ownerId },
+    select: { id: true },
+  });
+  for (const child of children) {
+    await deleteFolder(child.id, ownerId);
+  }
+
+  await prisma.file.deleteMany({ where: { parentId: id, ownerId } });
+
+  return prisma.folder.delete({ where: { id } });
+}
+
+export async function renameFolder(id: number, name: string, ownerId: string) {
+  const folder = await prisma.folder.findUnique({ where: { id } });
+  if (!folder || folder.ownerId !== ownerId) {
+    throw new Error('Folder not found');
+  }
+
+  return prisma.folder.update({
+    where: { id },
+    data: { name },
+  });
+}

--- a/backend/src/routes/folders.ts
+++ b/backend/src/routes/folders.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance } from 'fastify';
-import { createFolder, getFolders } from '@/controllers/folders';
+import { createFolder, getFolders, deleteFolder, renameFolder } from '@/controllers/folders';
 import { verifySession } from '@/controllers/auth';
 
 console.log("Loading folders.ts");
@@ -19,6 +19,23 @@ export default async function (app: FastifyInstance) {
     const user = await verifySession(token);
     const { name, parentId } = request.body as any;
     const folder = await createFolder({ name, parentId: parentId ?? null, ownerId: user.id });
+    reply.send(folder);
+  });
+
+  app.delete('/api/folders/:id', async (request, reply) => {
+    const token = (request.headers.authorization || '').replace('Bearer ', '');
+    const user = await verifySession(token);
+    const id = Number((request.params as any).id);
+    const deleted = await deleteFolder(id, user.id);
+    reply.send(deleted);
+  });
+
+  app.patch('/api/folders/:id', async (request, reply) => {
+    const token = (request.headers.authorization || '').replace('Bearer ', '');
+    const user = await verifySession(token);
+    const id = Number((request.params as any).id);
+    const { name } = request.body as any;
+    const folder = await renameFolder(id, name, user.id);
     reply.send(folder);
   });
 }


### PR DESCRIPTION
## Summary
- Implement recursive folder deletion and renaming controllers
- Add DELETE and PATCH folder routes for API

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c3df29537c8331bd9451b36486d291