### PR TITLE
Store file paths and clean up Supabase objects on file deletion

### DIFF
--- a/backend/src/controllers/files.ts
+++ b/backend/src/controllers/files.ts
@@ -1,4 +1,5 @@
 import prisma from '@/services/prisma';
+import { supabaseAdmin } from '@/services/supabase';
 
 export function getFiles(parentId: number, ownerId: string) {
   return prisma.file.findMany({
@@ -11,14 +12,17 @@ export function createFile(args: {
   name: string;
   size: number;
   url: string;
+  path: string;
   parentId: number;
   ownerId: string;
 }) {
   return prisma.file.create({ data: args });
 }
 
-export function deleteFile(id: number, ownerId: string) {
-  return prisma.file.delete({
+export async function deleteFile(id: number, ownerId: string) {
+  const file = await prisma.file.delete({
     where: { id, ownerId },
   });
+  await supabaseAdmin.storage.from('files').remove([file.path]);
+  return file;
 }

--- a/backend/src/models/schema.prisma
+++ b/backend/src/models/schema.prisma
@@ -35,6 +35,7 @@ model File {
   name      String
   size      Int
   url       String
+  path      String
   parentId  Int
   ownerId   String
   createdAt DateTime @default(now())

--- a/frontend/src/hooks/useUpload.ts
+++ b/frontend/src/hooks/useUpload.ts
@@ -11,7 +11,6 @@ export function useUpload() {
       .upload(`${session.user.id}/${Date.now()}-${file.name}`, file);
 
     if (error) throw error;
-
     const url = supabaseClient.storage.from('files').getPublicUrl(data.path).data.publicUrl;
 
     const res = await fetch('/api/files', {
@@ -24,6 +23,7 @@ export function useUpload() {
         name: file.name,
         size: file.size,
         url,
+        path: data.path,
         parentId
       })
     })


### PR DESCRIPTION
## Summary
- track storage object path in Prisma `File` model and create API
- delete file objects from Supabase storage when removing records
- send path from frontend upload to backend API

## Testing
- `yarn prisma:generate`
- `npx tsc --noEmit`
- `yarn build` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68c3df2357288331aa265ca6bf6cd9b1