### PR TITLE
Use signed URLs for file access

### DIFF
--- a/frontend/src/hooks/useUpload.ts
+++ b/frontend/src/hooks/useUpload.ts
@@ -11,7 +11,15 @@ export function useUpload() {
       .upload(`${session.user.id}/${Date.now()}-${file.name}`, file);
 
     if (error) throw error;
-    const url = supabaseClient.storage.from('files').getPublicUrl(data.path).data.publicUrl;
+
+    const { data: signedData, error: signedError } = await supabaseClient
+      .storage
+      .from('files')
+      .createSignedUrl(data.path, 60);
+
+    if (signedError) throw signedError;
+
+    const url = signedData.signedUrl;
 
     const res = await fetch('/api/files', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- generate a signed URL after uploads instead of exposing a public URL
- serve file lists with fresh signed URLs from the backend

## Testing
- ⚠️ `npm test` (frontend) - no test script
- ✅ `npm run build` (frontend)
- ⚠️ `npm test` (backend) - no test script
- ⚠️ `npm run build` (backend) - missing type modules


------
https://chatgpt.com/codex/tasks/task_e_68c3e2101e44833192ea31471835b319