### PR TITLE
feat: add breadcrumb component

### DIFF
--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -1,0 +1,35 @@
+import { ChevronRight, Home } from "lucide-react"
+
+export interface Crumb {
+  id: number | null
+  name: string
+}
+
+interface BreadcrumbProps {
+  crumbs: Crumb[]
+  onNavigate: (index: number) => void
+}
+
+export default function Breadcrumb({ crumbs, onNavigate }: BreadcrumbProps) {
+  return (
+    <div className="bg-slate-800/60 backdrop-blur-sm border-b border-slate-700/30 px-6 py-3">
+      <div className="flex items-center space-x-2 text-sm">
+        {crumbs.map((crumb, index) => (
+          <div key={index} className="flex items-center space-x-2 animate-in fade-in duration-200">
+            {index === 0 && <Home className="w-4 h-4 text-slate-400" />}
+            <button
+              onClick={() => onNavigate(index)}
+              className="text-slate-300 hover:text-blue-400 transition-colors duration-200 font-medium"
+            >
+              {crumb.name}
+            </button>
+            {index < crumbs.length - 1 && (
+              <ChevronRight className="w-4 h-4 text-slate-500" />
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+

--- a/frontend/src/pages/DriveView.tsx
+++ b/frontend/src/pages/DriveView.tsx
@@ -5,6 +5,7 @@ import { useParams, useNavigate, useLocation } from "react-router-dom"
 import FolderCard from "@/components/FolderCard"
 import FileCard from "@/components/FileCard"
 import UploadButton from "@/components/UploadButton"
+import Breadcrumb, { Crumb } from "@/components/Breadcrumb"
 import { useFolders } from "@/hooks/useFolders"
 import { useFiles } from "@/hooks/useFiles"
 import { Button } from "@/components/ui/button"
@@ -22,8 +23,6 @@ import {
   Grid3X3,
   List,
   MoreVertical,
-  Home,
-  ChevronRight,
   Cloud,
 } from "lucide-react"
 import { useAuth } from '@/hooks/useAuth'
@@ -34,11 +33,6 @@ function formatBytes(bytes: number) {
   const sizes = ["B", "KB", "MB", "GB", "TB"]
   const i = Math.floor(Math.log(bytes) / Math.log(k))
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`
-}
-
-interface Crumb {
-  id: number | null
-  name: string
 }
 
 export default function DriveView() {
@@ -133,24 +127,7 @@ export default function DriveView() {
         </div>
       </div>
 
-      <div className="bg-slate-800/60 backdrop-blur-sm border-b border-slate-700/30 px-6 py-3">
-        <div className="flex items-center space-x-2 text-sm">
-          {breadcrumbs.map((crumb, index) => (
-            <div key={index} className="flex items-center space-x-2 animate-in fade-in duration-200">
-              {index === 0 && <Home className="w-4 h-4 text-slate-400" />}
-              <button
-                onClick={() => navigateToBreadcrumb(index)}
-                className="text-slate-300 hover:text-blue-400 transition-colors duration-200 font-medium"
-              >
-                {crumb.name}
-              </button>
-              {index < breadcrumbs.length - 1 && (
-                <ChevronRight className="w-4 h-4 text-slate-500" />
-              )}
-            </div>
-          ))}
-        </div>
-      </div>
+      <Breadcrumb crumbs={breadcrumbs} onNavigate={navigateToBreadcrumb} />
 
       <div className="p-6">
         {items.length === 0 ? (


### PR DESCRIPTION
## Summary
- build reusable Breadcrumb component for drive navigation
- use Breadcrumb in DriveView instead of inline markup

## Testing
- `cd frontend && yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68c3e362784883319c90455a75d6efa5