### PR TITLE
feat: add folder creation

### DIFF
--- a/frontend/src/hooks/useFolders.ts
+++ b/frontend/src/hooks/useFolders.ts
@@ -5,15 +5,33 @@ export function useFolders(parentId: number | null) {
   const { session } = useAuth();
   const [folders, setFolders] = useState<any[]>([]);
 
-  useEffect(() => {
+  const fetchFolders = async () => {
     if (!session) return;
     const token = session.access_token;
-    fetch(`/api/folders/${parentId ?? ''}`, {
+    const res = await fetch(`/api/folders/${parentId ?? ''}`, {
       headers: { Authorization: `Bearer ${token}` }
-    })
-      .then(res => res.json())
-      .then(setFolders);
+    });
+    const data = await res.json();
+    setFolders(data);
+  };
+
+  useEffect(() => {
+    fetchFolders();
   }, [parentId, session]);
 
-  return folders;
+  const createFolder = async (name: string) => {
+    if (!session) return;
+    const token = session.access_token;
+    await fetch('/api/folders', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ name, parentId })
+    });
+    await fetchFolders();
+  };
+
+  return { folders, createFolder, refetch: fetchFolders };
 }

--- a/frontend/src/pages/DriveView.tsx
+++ b/frontend/src/pages/DriveView.tsx
@@ -24,6 +24,7 @@ import {
   List,
   MoreVertical,
   Cloud,
+  FolderPlus,
 } from "lucide-react"
 import { useAuth } from '@/hooks/useAuth'
 
@@ -45,7 +46,7 @@ export default function DriveView() {
 
   const currentFolderId = folderId === "root" ? 0 : Number(folderId)
 
-  const folders = useFolders(currentFolderId === 0 ? null : currentFolderId)
+  const { folders, createFolder } = useFolders(currentFolderId === 0 ? null : currentFolderId)
   const { files, refetch } = useFiles(currentFolderId)
 
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid")
@@ -77,6 +78,13 @@ export default function DriveView() {
     navigate(crumb.id === null ? "/drive/root" : `/drive/${crumb.id}`, {
       state: { breadcrumbs: newCrumbs },
     })
+  }
+
+  const handleCreateFolder = async () => {
+    const name = prompt('Folder name')
+    if (name && name.trim()) {
+      await createFolder(name.trim())
+    }
   }
 
   const items = [
@@ -117,6 +125,10 @@ export default function DriveView() {
               )}
             </Button>
             <UploadButton parentId={currentFolderId} onUploaded={refetch} />
+            <Button onClick={handleCreateFolder}>
+              <FolderPlus className="w-4 h-4 mr-2" />
+              New Folder
+            </Button>
             <Button 
               variant="default" 
               onClick={signOut} 


### PR DESCRIPTION
## Summary
- add ability to create folders with API call and refresh hook
- add "New Folder" button in drive view to prompt and create folders

## Testing
- `npm test` *(frontend)*
- `npm run build` *(frontend, fails: Rollup failed to resolve import "posthog-js")*
- `npm test` *(backend)*


------
https://chatgpt.com/codex/tasks/task_e_68c3e4f61fe8833195240917a6592aee