### PR TITLE
fix: wire up new folder button

### DIFF
--- a/frontend/src/pages/DriveView.tsx
+++ b/frontend/src/pages/DriveView.tsx
@@ -47,7 +47,7 @@ export default function DriveView() {
 
   const currentFolderId = folderId === "root" ? 0 : Number(folderId)
 
-  const { folders, renameFolder, deleteFolder } = useFolders(currentFolderId === 0 ? null : currentFolderId)
+  const { folders, refetch: refetchFolders, renameFolder, deleteFolder } = useFolders(currentFolderId === 0 ? null : currentFolderId)
   const { files, refetch } = useFiles(currentFolderId)
 
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid")
@@ -82,6 +82,24 @@ export default function DriveView() {
   }
 
   const token = session?.access_token
+
+  const handleCreateFolder = async () => {
+    if (!token) return
+    const name = window.prompt('Folder name')
+    if (!name) return
+    await fetch('/api/folders', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        name,
+        parentId: currentFolderId === 0 ? null : currentFolderId,
+      }),
+    })
+    refetchFolders()
+  }
 
   const handleDelete = async (id: number) => {
     if (!token) return


### PR DESCRIPTION
## Summary
- add missing folder creation handler in DriveView
- refresh folder list after creating a folder

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c3d2ec6eac8331a673bd0fb2e4e779