### PR TITLE
feat: validate front-end env vars with zod

### DIFF
--- a/frontend/src/contexts/SupabaseContext.tsx
+++ b/frontend/src/contexts/SupabaseContext.tsx
@@ -1,6 +1,7 @@
 import { createClient } from "@supabase/supabase-js";
+import { env } from "@/env";
 
-const url = import.meta.env.VITE_SUPABASE_URL!;
-const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY!;
-
-export const supabaseClient = createClient(url, anonKey);
+export const supabaseClient = createClient(
+  env.VITE_SUPABASE_URL,
+  env.VITE_SUPABASE_ANON_KEY
+);

--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  VITE_SUPABASE_URL: z.string().url(),
+  VITE_SUPABASE_ANON_KEY: z.string().min(1),
+  VITE_POSTHOG_KEY: z.string().optional(),
+});
+
+const _env = envSchema.safeParse(import.meta.env);
+
+if (!_env.success) {
+  const message = _env.error.issues
+    .map((i) => `${i.path.join('.')}: ${i.message}`)
+    .join('; ');
+  throw new Error(`Invalid environment variables: ${message}`);
+}
+
+export const env = _env.data;

--- a/frontend/src/lib/posthog.ts
+++ b/frontend/src/lib/posthog.ts
@@ -1,7 +1,8 @@
 import posthog from 'posthog-js';
+import { env } from '@/env';
 
 export function initPosthog() {
-  const key = import.meta.env.VITE_POSTHOG_KEY;
+  const key = env.VITE_POSTHOG_KEY;
   if (!key) return;
 
   posthog.init(key, {


### PR DESCRIPTION
## Summary
- add `frontend/src/env.ts` using zod to validate `import.meta.env`
- use parsed env vars in Supabase and Posthog clients

## Testing
- `VITE_SUPABASE_URL=http://example.com VITE_SUPABASE_ANON_KEY=anon yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68c3fcdbd0308331bc88be995c2ce8db