### PR TITLE
refactor: add prisma types

### DIFF
--- a/frontend/src/components/FileCard.tsx
+++ b/frontend/src/components/FileCard.tsx
@@ -1,8 +1,9 @@
-import { File, FileText, ImageIcon, Video, Music, Archive } from 'lucide-react'
+import { File as FileIcon, FileText, ImageIcon, Video, Music, Archive } from 'lucide-react'
+import type { File as PrismaFile } from '@prisma/client'
 import type React from 'react'
 
 export interface FileCardProps {
-  name: string
+  file: PrismaFile
   size?: string
   modified?: string
   onClick?: () => void
@@ -36,17 +37,18 @@ function getIcon(fileName: string, big = false) {
     case '7z':
       return <Archive className={`${size} text-yellow-400`} />
     default:
-      return <File className={`${size} text-slate-400`} />
+      return <FileIcon className={`${size} text-slate-400`} />
   }
 }
 
 export default function FileCard({
-  name,
+  file,
   size,
   modified,
   onClick,
   view = 'list',
 }: FileCardProps) {
+  const { name } = file
   if (view === 'grid') {
     return (
       <button

--- a/frontend/src/components/FolderCard.tsx
+++ b/frontend/src/components/FolderCard.tsx
@@ -1,19 +1,21 @@
-import { Folder } from 'lucide-react'
+import { Folder as FolderIcon } from 'lucide-react'
+import type { Folder } from '@prisma/client'
 import type React from 'react'
 
 export interface FolderCardProps {
-  name: string
+  folder: Folder
   modified?: string
   onClick?: () => void
   view?: 'grid' | 'list'
 }
 
 export default function FolderCard({
-  name,
+  folder,
   modified,
   onClick,
   view = 'list',
 }: FolderCardProps) {
+  const { name } = folder
   if (view === 'grid') {
     return (
       <button
@@ -21,7 +23,7 @@ export default function FolderCard({
         onClick={onClick}
         className="flex flex-col items-center justify-center space-y-2 w-full"
       >
-        <Folder className="w-12 h-12 text-blue-400" />
+        <FolderIcon className="w-12 h-12 text-blue-400" />
         <span className="text-sm font-medium text-slate-200 truncate w-full text-center">
           {name}
         </span>
@@ -40,7 +42,7 @@ export default function FolderCard({
       onClick={onClick}
       className="flex items-center space-x-3 text-left hover:bg-slate-800/40 p-2 rounded-md w-full"
     >
-      <Folder className="w-6 h-6 text-blue-400" />
+      <FolderIcon className="w-6 h-6 text-blue-400" />
       <div className="flex flex-col flex-1">
         <span className="font-medium text-slate-200">{name}</span>
         {modified && <span className="text-sm text-slate-400">{modified}</span>}

--- a/frontend/src/hooks/useFiles.ts
+++ b/frontend/src/hooks/useFiles.ts
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
+import { type File as PrismaFile } from '@prisma/client';
 import { useAuth } from './useAuth';
 
 export function useFiles(parentId: number) {
   const { session } = useAuth();
-  const [files, setFiles] = useState<any[]>([]);
+  const [files, setFiles] = useState<PrismaFile[]>([]);
 
   const fetchFiles = async () => {
     if (!session) return;
@@ -11,7 +12,7 @@ export function useFiles(parentId: number) {
     const res = await fetch(`/api/files/${parentId}`, {
       headers: { Authorization: `Bearer ${token}` }
     });
-    const data = await res.json();
+    const data: PrismaFile[] = await res.json();
     setFiles(data);
   };
 

--- a/frontend/src/hooks/useFolders.ts
+++ b/frontend/src/hooks/useFolders.ts
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
+import { type Folder } from '@prisma/client';
 import { useAuth } from './useAuth';
 
 export function useFolders(parentId: number | null) {
   const { session } = useAuth();
-  const [folders, setFolders] = useState<any[]>([]);
+  const [folders, setFolders] = useState<Folder[]>([]);
 
   const fetchFolders = async () => {
     if (!session) return;
@@ -11,7 +12,7 @@ export function useFolders(parentId: number | null) {
     const res = await fetch(`/api/folders/${parentId ?? ''}`, {
       headers: { Authorization: `Bearer ${token}` }
     });
-    const data = await res.json();
+    const data: Folder[] = await res.json();
     setFolders(data);
   };
 
@@ -32,7 +33,7 @@ export function useFolders(parentId: number | null) {
       },
       body: JSON.stringify({ name })
     });
-    const data = await res.json();
+    const data: Folder = await res.json();
     setFolders((prev) => prev.map((f) => (f.id === id ? data : f)));
   };
 

--- a/frontend/src/pages/DriveView.tsx
+++ b/frontend/src/pages/DriveView.tsx
@@ -26,6 +26,7 @@ import {
   Cloud,
   FolderPlus,
 } from "lucide-react"
+import type { Folder, File as PrismaFile } from '@prisma/client'
 import { useAuth } from '@/hooks/useAuth'
 import { supabaseClient } from '@/contexts/SupabaseContext'
 
@@ -110,7 +111,7 @@ export default function DriveView() {
     refetch()
   }
 
-  const handleDownload = async (file: any) => {
+  const handleDownload = async (file: PrismaFile) => {
     const { data } = await supabaseClient.storage.from('files').download(file.path)
     if (data) {
       const url = URL.createObjectURL(data)
@@ -122,7 +123,7 @@ export default function DriveView() {
     }
   }
 
-  const handleRename = async (file: any) => {
+  const handleRename = async (file: PrismaFile) => {
     if (!token) return
     const newName = window.prompt('Enter new name', file.name)
     if (!newName || newName === file.name) return
@@ -137,9 +138,13 @@ export default function DriveView() {
     refetch()
   }
 
-  const items = [
-    ...filteredFolders.map((f) => ({ ...f, type: "folder" as const })),
-    ...filteredFiles.map((f) => ({ ...f, type: "file" as const })),
+  type FolderItem = Folder & { type: 'folder' }
+  type FileItem = PrismaFile & { type: 'file' }
+  type Item = FolderItem | FileItem
+
+  const items: Item[] = [
+    ...filteredFolders.map((f): FolderItem => ({ ...f, type: 'folder' })),
+    ...filteredFiles.map((f): FileItem => ({ ...f, type: 'file' })),
   ]
 
   return (
@@ -218,13 +223,13 @@ export default function DriveView() {
                     <CardContent className="p-4 text-center relative">
                       {item.type === "folder" ? (
                         <FolderCard
-                          name={item.name}
+                          folder={item}
                           view="grid"
                           onClick={() => openFolder(item.id, item.name)}
                         />
                       ) : (
                         <FileCard
-                          name={item.name}
+                          file={item}
                           view="grid"
                           size={formatBytes(item.size)}
                           modified={new Date(item.createdAt).toLocaleDateString()}
@@ -269,13 +274,13 @@ export default function DriveView() {
                     <div className="flex items-center space-x-3 flex-1">
                       {item.type === "folder" ? (
                         <FolderCard
-                          name={item.name}
+                          folder={item}
                           view="list"
                           onClick={() => openFolder(item.id, item.name)}
                         />
                       ) : (
                         <FileCard
-                          name={item.name}
+                          file={item}
                           view="list"
                           size={formatBytes(item.size)}
                           modified={new Date(item.createdAt).toLocaleDateString()}


### PR DESCRIPTION
## Summary
- use Prisma-generated `Folder` and `File` types in hooks
- type `FolderCard` and `FileCard` props to accept full entities
- update `DriveView` to work with typed folder and file data

## Testing
- `npx -y vitest run` *(fails: Cannot find dependency 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68c3fce781108331b8568b4ede4abc9a