### PR TITLE
feat: show upload progress bar

### DIFF
--- a/frontend/src/components/UploadButton.tsx
+++ b/frontend/src/components/UploadButton.tsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react'
 import { Upload } from 'lucide-react'
 import { Button } from './ui/button'
+import { Progress } from './ui/progress'
 import { useUpload } from '@/hooks/useUpload'
 import { toast } from 'sonner'
 
@@ -11,7 +12,7 @@ export interface UploadButtonProps {
 
 export default function UploadButton({ parentId, onUploaded }: UploadButtonProps) {
   const inputRef = useRef<HTMLInputElement>(null)
-  const { uploadFile } = useUpload()
+  const { uploadFile, progress } = useUpload()
 
   const MAX_SIZE_MB = 10
   const allowedTypes = [
@@ -60,10 +61,15 @@ export default function UploadButton({ parentId, onUploaded }: UploadButtonProps
         className="hidden"
         onChange={handleChange}
       />
-      <Button onClick={() => inputRef.current?.click()}>
+      <Button onClick={() => inputRef.current?.click()} disabled={!!progress}>
         <Upload className="w-4 h-4 mr-2" />
         Upload
       </Button>
+      {progress && (
+        <div className="w-full mt-2">
+          <Progress value={(progress.loaded / progress.total) * 100} />
+        </div>
+      )}
     </>
   )
 }

--- a/frontend/src/components/ui/progress.tsx
+++ b/frontend/src/components/ui/progress.tsx
@@ -1,0 +1,27 @@
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+
+import { cn } from "@/lib/utils"
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-2 w-full overflow-hidden rounded-full bg-secondary",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-primary transition-all"
+      style={{ transform: `translateX(-${100 - (value ?? 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+))
+
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }


### PR DESCRIPTION
## Summary
- track bytes uploaded in useUpload with an XMLHttpRequest
- return upload progress from useUpload and show a progress bar in UploadButton
- add Progress UI component

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68c40a6892548331825e88904582c627