### PR TITLE
Add name metadata to signup and display in UI

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -3,7 +3,7 @@ import { Button } from './ui/button'
 import { useAuth } from '@/hooks/useAuth'
 
 export default function Navbar() {
-  const { signOut } = useAuth()
+  const { user, signOut } = useAuth()
 
   return (
     <nav className="flex items-center justify-between px-4 py-2 bg-slate-800 border-b border-slate-700">
@@ -11,9 +11,14 @@ export default function Navbar() {
         <Cloud className="w-5 h-5 text-white" />
         <span className="text-lg font-bold text-white">KDrive</span>
       </div>
-      <Button variant="ghost" onClick={signOut} className="text-slate-300 hover:text-white">
-        Sign Out
-      </Button>
+      <div className="flex items-center space-x-4">
+        {user?.user_metadata?.name && (
+          <span className="text-slate-300">{user.user_metadata.name}</span>
+        )}
+        <Button variant="ghost" onClick={signOut} className="text-slate-300 hover:text-white">
+          Sign Out
+        </Button>
+      </div>
     </nav>
   )
 }

--- a/frontend/src/hooks/__tests__/useAuth.test.tsx
+++ b/frontend/src/hooks/__tests__/useAuth.test.tsx
@@ -3,9 +3,10 @@ import { AuthContext } from '@/contexts/AuthContext'
 
 vi.mock('@/contexts/SupabaseContext', () => {
   const auth = {
-    signInWithPassword: vi.fn(),
-    signUp: vi.fn(),
-    signOut: vi.fn(),
+    signInWithPassword: vi.fn().mockResolvedValue({ data: {}, error: null }),
+    signUp: vi.fn().mockResolvedValue({ data: {}, error: null }),
+    signOut: vi.fn().mockResolvedValue({ error: null }),
+    updateUser: vi.fn().mockResolvedValue({ data: {}, error: null }),
   }
   return { supabaseClient: { auth } }
 })
@@ -13,7 +14,7 @@ vi.mock('@/contexts/SupabaseContext', () => {
 import { supabaseClient } from '@/contexts/SupabaseContext'
 import { useAuth } from '@/hooks/useAuth'
 
-const { signInWithPassword, signUp, signOut } = supabaseClient.auth as any
+const { signInWithPassword, signUp, signOut, updateUser } = supabaseClient.auth as any
 
 describe('useAuth', () => {
   const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -29,8 +30,9 @@ describe('useAuth', () => {
     await result.current.signInWithEmail('a@b.com', 'pw')
     expect(signInWithPassword).toHaveBeenCalledWith({ email: 'a@b.com', password: 'pw' })
 
-    await result.current.signUpWithEmail('c@d.com', 'pw')
+    await result.current.signUpWithEmail('c@d.com', 'pw', 'Jane')
     expect(signUp).toHaveBeenCalledWith({ email: 'c@d.com', password: 'pw' })
+    expect(updateUser).toHaveBeenCalledWith({ data: { name: 'Jane' } })
 
     await result.current.signOut()
     expect(signOut).toHaveBeenCalled()

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -9,8 +9,21 @@ export function useAuth() {
     return await supabaseClient.auth.signInWithPassword({ email, password })
   }
 
-  async function signUpWithEmail(email: string, password: string) {
-    return await supabaseClient.auth.signUp({ email, password })
+  async function signUpWithEmail(
+    email: string,
+    password: string,
+    name: string
+  ) {
+    const result = await supabaseClient.auth.signUp({ email, password })
+    if (!result.error) {
+      const { error } = await supabaseClient.auth.updateUser({
+        data: { name },
+      })
+      if (error) {
+        return { ...result, error }
+      }
+    }
+    return result
   }
 
   async function signOut() {

--- a/frontend/src/pages/SignIn.tsx
+++ b/frontend/src/pages/SignIn.tsx
@@ -13,11 +13,7 @@ import { Cloud, ArrowLeft, Eye, EyeOff, Loader2 } from "lucide-react"
 import { useAuth } from "@/hooks/useAuth"
 
 export default function SignInPage() {
-  const {
-    user,
-    signInWithEmail,
-    signUpWithEmail,
-  } = useAuth()
+  const { user, signInWithEmail, signUpWithEmail } = useAuth()
   const navigate = useNavigate()
   const [isSignUp, setIsSignUp] = useState(false)
   const [showPassword, setShowPassword] = useState(false)
@@ -39,7 +35,7 @@ export default function SignInPage() {
     setIsLoading(true)
 
     const { error } = isSignUp
-      ? await signUpWithEmail(email, password)
+      ? await signUpWithEmail(email, password, name)
       : await signInWithEmail(email, password)
 
     setIsLoading(false)


### PR DESCRIPTION
## Summary
- allow specifying a name during email signup and persist it as user metadata
- send name from SignIn page to signup method
- show the user's stored name in the navbar and cover in tests

## Testing
- `cd frontend && yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68c40a6ed81c8331b3efe215709834e4