### PR TITLE
feat: add drag and drop uploads

### DIFF
--- a/frontend/src/components/Dropzone.tsx
+++ b/frontend/src/components/Dropzone.tsx
@@ -1,0 +1,73 @@
+import { useState, PropsWithChildren } from 'react'
+import { useUpload } from '@/hooks/useUpload'
+import { toast } from 'sonner'
+
+export interface DropzoneProps extends PropsWithChildren {
+  parentId: number
+  onUploaded?: () => void
+}
+
+export default function Dropzone({ parentId, onUploaded, children }: DropzoneProps) {
+  const { uploadFile } = useUpload()
+  const [isDragging, setIsDragging] = useState(false)
+
+  const MAX_SIZE_MB = 10
+  const allowedTypes = ['image/', 'video/', 'text/', 'application/pdf']
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    setIsDragging(true)
+  }
+
+  const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+    if (e.currentTarget === e.target) {
+      setIsDragging(false)
+    }
+  }
+
+  const handleDrop = async (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    setIsDragging(false)
+
+    const files = Array.from(e.dataTransfer.files)
+
+    for (const file of files) {
+      const tooLarge = file.size > MAX_SIZE_MB * 1024 * 1024
+      const typeOk = allowedTypes.some(t => file.type.startsWith(t))
+
+      if (tooLarge || !typeOk) {
+        toast.error(
+          tooLarge ? `File too large (max ${MAX_SIZE_MB}MB)` : 'Unsupported file type'
+        )
+        continue
+      }
+
+      await toast.promise(uploadFile(file, parentId), {
+        loading: 'Uploading…',
+        success: 'File uploaded',
+        error: 'Upload failed',
+      })
+    }
+
+    if (files.length > 0) {
+      onUploaded?.()
+    }
+  }
+
+  return (
+    <div
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      className="relative"
+    >
+      {children}
+      {isDragging && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center rounded-lg border-2 border-dashed border-slate-500 bg-slate-900/80">
+          <p className="text-slate-300 text-lg">Drop files to upload</p>
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/frontend/src/pages/DriveView.tsx
+++ b/frontend/src/pages/DriveView.tsx
@@ -5,6 +5,7 @@ import { useParams, useNavigate, useLocation } from "react-router-dom"
 import FolderCard from "@/components/FolderCard"
 import FileCard from "@/components/FileCard"
 import UploadButton from "@/components/UploadButton"
+import Dropzone from "@/components/Dropzone"
 import Breadcrumb, { Crumb } from "@/components/Breadcrumb"
 import RenameFolderDialog from "@/components/RenameFolderDialog"
 import ConfirmFolderDeleteDialog from "@/components/ConfirmFolderDeleteDialog"
@@ -191,7 +192,8 @@ export default function DriveView() {
   ]
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
+    <Dropzone parentId={currentFolderId} onUploaded={refetch}>
+      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
       <NewFolderDialog
         open={newFolderOpen}
         onOpenChange={setNewFolderOpen}
@@ -413,6 +415,7 @@ export default function DriveView() {
         token={token}
         onClose={() => setFileToRename(null)}
         onRenamed={refetch}
+      />
       <RenameFolderDialog
         open={!!folderToRename}
         folderId={folderToRename?.id ?? 0}
@@ -435,6 +438,7 @@ export default function DriveView() {
           await deleteFolder(id)
         }}
       />
-    </div>
+      </div>
+    </Dropzone>
   )
 }


### PR DESCRIPTION
## Summary
- introduce dropzone component for drag-and-drop file uploads
- integrate dropzone into DriveView and hook to upload logic
- provide visual feedback for dragging

## Testing
- `cd frontend && yarn test --run`


------
https://chatgpt.com/codex/tasks/task_e_68c4135a42c88331bfe9c1495f3a01b9