### PR TITLE
Fix Supabase upload URL handling

### DIFF
--- a/backend/src/plugins/verifySession.ts
+++ b/backend/src/plugins/verifySession.ts
@@ -37,6 +37,7 @@ export default fp(async function verifySessionPlugin(app) {
       request.user = user;
     } catch {
       reply.code(401).send({ error: 'Unauthorized' });
+      return;
     }
   });
 });

--- a/frontend/src/hooks/useUpload.ts
+++ b/frontend/src/hooks/useUpload.ts
@@ -28,10 +28,8 @@ export function useUpload() {
 
     const storageUrl: string = (supabaseClient as any).storageUrl;
     const cleanPath = path.replace(/^\/|\/$/g, '').replace(/\/+/g, '/');
-    const uploadUrl = new URL(
-      `object/upload/sign/files/${cleanPath}`,
-      storageUrl
-    );
+    const baseUrl = storageUrl.endsWith('/') ? storageUrl : `${storageUrl}/`;
+    const uploadUrl = new URL(`object/upload/sign/files/${cleanPath}`, baseUrl);
     uploadUrl.searchParams.set('token', token);
 
     await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Summary
- ensure trailing slash when building storage upload URL
- stop processing after unauthorized in session verification

## Testing
- `cd backend && yarn test`
- `cd frontend && yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68c41fa047f88331a48bbd54c8bf58c6