### PR TITLE
Add prisma deploy script for backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Users can browse nested folders, upload files, and persist everything in your ow
       cd backend
       yarn prisma:migrate
       ```
+      When deploying, use the deploy subcommand instead:
+      ```bash
+      yarn prisma:deploy
+      ```
    3. Start the development server:
       ```bash
       yarn dev

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "start": "node dist/server.js",
     "prisma:reset": "prisma migrate reset --schema=src/models/schema.prisma --force",
     "prisma:migrate": "prisma migrate dev --schema=src/models/schema.prisma --name init",
+    "prisma:deploy": "prisma migrate deploy --schema=src/models/schema.prisma",
     "prisma:generate": "prisma generate --schema=src/models/schema.prisma",
     "prisma:seed": "tsx src/models/seed.ts",
     "test-db": "tsx src/utils/test-db.ts",
@@ -22,8 +23,8 @@
     "dotenv": "^16.5.0",
     "fastify": "^5",
     "fastify-type-provider-zod": "^6.0.0",
-    "postgres": "^3.4.7",
     "pino": "^9.9.5",
+    "postgres": "^3.4.7",
     "zod": "^4.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add `prisma:deploy` script to backend
- document using `yarn prisma:deploy` for production deployments

## Testing
- `yarn lint`
- `yarn test`
- `yarn prisma:deploy` *(fails: Environment variable not found: DIRECT_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68c50d3f7af0833198e3842420b74622