### PR TITLE
feat: enforce DIRECT_URL env variable

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 
 export const DATABASE_URL = process.env.DATABASE_URL || '';
+export const DIRECT_URL = process.env.DIRECT_URL || '';
 // Prefer backend env names; fall back to Vite-prefixed names if present.
 export const SUPABASE_URL =
   process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || '';
@@ -15,6 +16,7 @@ export const POSTHOG_API_KEY = process.env.POSTHOG_API_KEY || '';
 
 const missing: string[] = [];
 if (!DATABASE_URL) missing.push('DATABASE_URL');
+if (!DIRECT_URL) missing.push('DIRECT_URL');
 if (!SUPABASE_URL) missing.push('SUPABASE_URL or VITE_SUPABASE_URL');
 if (!SUPABASE_SERVICE_ROLE_KEY) missing.push('SUPABASE_SERVICE_ROLE_KEY');
 

--- a/backend/src/models/seed.ts
+++ b/backend/src/models/seed.ts
@@ -1,5 +1,6 @@
 // prisma/seed.ts
 import { PrismaClient } from "@prisma/client";
+import "@/config/env";
 
 const prisma = new PrismaClient();
 

--- a/backend/src/services/prisma.ts
+++ b/backend/src/services/prisma.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import '@/config/env';
 
 const prisma = new PrismaClient();
 

--- a/backend/test/unauthorized.test.ts
+++ b/backend/test/unauthorized.test.ts
@@ -3,6 +3,7 @@ import Fastify from 'fastify';
 
 // Provide dummy environment variables expected by the plugin
 process.env.DATABASE_URL = 'postgresql://localhost/test';
+process.env.DIRECT_URL = 'postgresql://localhost/test';
 process.env.SUPABASE_URL = 'http://localhost';
 process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role';
 process.env.SUPABASE_ANON_KEY = 'anon-key';

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     setupFiles: ['./tests/setup.ts'],
     env: {
       DATABASE_URL: 'postgres://localhost/test',
+      DIRECT_URL: 'postgres://localhost/test',
       SUPABASE_URL: 'http://localhost',
       SUPABASE_SERVICE_ROLE_KEY: 'test',
     },


### PR DESCRIPTION
## Summary
- require `DIRECT_URL` in backend env checks
- load env in Prisma scripts
- add `DIRECT_URL` to test and dev configs

## Testing
- `npx -y yarn@1.22.19 test`
- `DATABASE_URL=postgresql://localhost/test SUPABASE_URL=http://localhost SUPABASE_SERVICE_ROLE_KEY=key npx -y yarn@1.22.19 dev` *(fails: Missing environment variables: DIRECT_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68c6441793448331a273d11af0eeb3dd