### PR TITLE
Add theme toggling support and align color tokens with theme variables

### DIFF
--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -12,20 +12,18 @@ interface BreadcrumbProps {
 
 export default function Breadcrumb({ crumbs, onNavigate }: BreadcrumbProps) {
   return (
-    <div className="bg-slate-800/60 backdrop-blur-sm border-b border-slate-700/30 px-6 py-3">
-      <div className="flex items-center space-x-2 text-sm">
+    <div className="border-b border-border/40 bg-muted/60 px-6 py-3 backdrop-blur-sm">
+      <div className="flex items-center space-x-2 text-sm text-muted-foreground">
         {crumbs.map((crumb, index) => (
           <div key={index} className="flex items-center space-x-2 animate-in fade-in duration-200">
-            {index === 0 && <Home className="w-4 h-4 text-slate-400" />}
+            {index === 0 && <Home className="h-4 w-4" />}
             <button
               onClick={() => onNavigate(index)}
-              className="text-slate-300 hover:text-blue-400 transition-colors duration-200 font-medium"
+              className="font-medium text-foreground transition-colors duration-200 hover:text-primary"
             >
               {crumb.name}
             </button>
-            {index < crumbs.length - 1 && (
-              <ChevronRight className="w-4 h-4 text-slate-500" />
-            )}
+            {index < crumbs.length - 1 && <ChevronRight className="h-4 w-4" />}
           </div>
         ))}
       </div>

--- a/frontend/src/components/FileCard.tsx
+++ b/frontend/src/components/FileCard.tsx
@@ -36,7 +36,7 @@ function getIcon(fileName: string, big = false) {
     case '7z':
       return <Archive className={`${size} text-yellow-400`} />
     default:
-      return <File className={`${size} text-slate-400`} />
+      return <File className={`${size} text-muted-foreground`} />
   }
 }
 
@@ -52,14 +52,14 @@ export default function FileCard({
       <button
         type="button"
         onClick={onClick}
-        className="flex flex-col items-center justify-center space-y-2 w-full"
+        className="flex w-full flex-col items-center justify-center space-y-2"
       >
         {getIcon(name, true)}
-        <span className="text-sm font-medium text-slate-200 truncate w-full text-center">
+        <span className="w-full truncate text-center text-sm font-medium text-foreground">
           {name}
         </span>
         {(size || modified) && (
-          <span className="text-xs text-slate-400 truncate w-full text-center">
+          <span className="w-full truncate text-center text-xs text-muted-foreground">
             {modified}
             {modified && size && ' • '}
             {size}
@@ -73,13 +73,13 @@ export default function FileCard({
     <button
       type="button"
       onClick={onClick}
-      className="flex items-center space-x-3 text-left hover:bg-slate-800/40 p-2 rounded-md w-full"
+      className="flex w-full items-center space-x-3 rounded-md p-2 text-left transition-colors hover:bg-muted/60"
     >
       {getIcon(name)}
       <div className="flex flex-col flex-1">
-        <span className="font-medium text-slate-200">{name}</span>
+        <span className="font-medium text-foreground">{name}</span>
         {(size || modified) && (
-          <span className="text-sm text-slate-400">
+          <span className="text-sm text-muted-foreground">
             {modified}
             {modified && size && ' • '}
             {size}

--- a/frontend/src/components/FolderCard.tsx
+++ b/frontend/src/components/FolderCard.tsx
@@ -19,14 +19,14 @@ export default function FolderCard({
       <button
         type="button"
         onClick={onClick}
-        className="flex flex-col items-center justify-center space-y-2 w-full"
+        className="flex w-full flex-col items-center justify-center space-y-2"
       >
         <Folder className="w-12 h-12 text-blue-400" />
-        <span className="text-sm font-medium text-slate-200 truncate w-full text-center">
+        <span className="w-full truncate text-center text-sm font-medium text-foreground">
           {name}
         </span>
         {modified && (
-          <span className="text-xs text-slate-400 truncate w-full text-center">
+          <span className="w-full truncate text-center text-xs text-muted-foreground">
             {modified}
           </span>
         )}
@@ -38,12 +38,12 @@ export default function FolderCard({
     <button
       type="button"
       onClick={onClick}
-      className="flex items-center space-x-3 text-left hover:bg-slate-800/40 p-2 rounded-md w-full"
+      className="flex w-full items-center space-x-3 rounded-md p-2 text-left transition-colors hover:bg-muted/60"
     >
       <Folder className="w-6 h-6 text-blue-400" />
       <div className="flex flex-col flex-1">
-        <span className="font-medium text-slate-200">{name}</span>
-        {modified && <span className="text-sm text-slate-400">{modified}</span>}
+        <span className="font-medium text-foreground">{name}</span>
+        {modified && <span className="text-sm text-muted-foreground">{modified}</span>}
       </div>
     </button>
   )

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,8 +1,9 @@
-import { Cloud, FolderPlus, Grid3X3, List, Search } from "lucide-react"
+import { Cloud, FolderPlus, Grid3X3, List, Moon, Search, Sun } from "lucide-react"
 import UploadButton from "./UploadButton"
 import { Input } from "./ui/input"
 import { Button } from "./ui/button"
 import { useAuth } from "@/hooks/useAuth"
+import { useTheme } from "@/contexts/ThemeContext"
 
 type ViewMode = "grid" | "list"
 
@@ -26,22 +27,23 @@ export default function Navbar({
   onUploadComplete,
 }: NavbarProps) {
   const { signOut } = useAuth()
+  const { theme, toggleTheme } = useTheme()
 
   return (
-    <header className="sticky top-0 z-20 border-b border-slate-700/60 bg-slate-900/80 backdrop-blur-xl">
+    <header className="sticky top-0 z-20 border-b border-border/60 bg-background/80 backdrop-blur-xl supports-[backdrop-filter]:bg-background/70">
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-4 px-4 py-4 sm:px-6 lg:flex-row lg:items-center lg:justify-between lg:px-8">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:gap-6">
           <div className="flex items-center gap-2">
-            <Cloud className="h-6 w-6 text-white" />
-            <span className="text-xl font-semibold tracking-tight text-white">KDrive</span>
+            <Cloud className="h-6 w-6 text-primary" />
+            <span className="text-xl font-semibold tracking-tight text-foreground">KDrive</span>
           </div>
           <div className="relative w-full min-w-[16rem] max-w-xl lg:w-96">
-            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <Input
               placeholder="Search in Drive"
               value={searchQuery}
               onChange={(event) => onSearchChange(event.target.value)}
-              className="h-11 w-full rounded-xl border-slate-600 bg-slate-800/70 pl-10 text-sm text-slate-100 placeholder:text-slate-400 focus:border-slate-500 focus:bg-slate-800 focus-visible:ring-0"
+              className="h-11 w-full rounded-xl border border-input bg-muted/70 pl-10 text-sm text-foreground shadow-none transition-colors focus:bg-background focus-visible:ring-0"
             />
           </div>
         </div>
@@ -49,8 +51,18 @@ export default function Navbar({
           <Button
             variant="outline"
             size="icon"
+            onClick={toggleTheme}
+            aria-label="Toggle theme"
+            aria-pressed={theme === "dark"}
+            className="h-11 w-11 rounded-full border border-input bg-muted/60 text-foreground transition-colors duration-200 hover:bg-muted"
+          >
+            {theme === "dark" ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
             onClick={onToggleView}
-            className="h-11 w-11 rounded-full border-slate-600 bg-slate-800/70 text-slate-200 transition-colors duration-200 hover:bg-slate-700 hover:text-white"
+            className="h-11 w-11 rounded-full border border-input bg-muted/60 text-foreground transition-colors duration-200 hover:bg-muted"
             aria-label="Toggle view"
           >
             {viewMode === "grid" ? (
@@ -62,7 +74,7 @@ export default function Navbar({
           <UploadButton
             parentId={currentFolderId}
             onUploaded={onUploadComplete}
-            className="w-full min-[420px]:w-auto rounded-xl bg-slate-700/60 text-sm font-medium text-slate-100 transition-colors duration-200 hover:bg-slate-600"
+            className="w-full min-[420px]:w-auto rounded-xl bg-muted text-sm font-medium text-foreground transition-colors duration-200 hover:bg-muted/80"
           />
           <Button
             onClick={onCreateFolder}

--- a/frontend/src/components/SkeletonCard.tsx
+++ b/frontend/src/components/SkeletonCard.tsx
@@ -7,19 +7,19 @@ export interface SkeletonCardProps {
 const SkeletonCard: FC<SkeletonCardProps> = ({ view = "grid" }) => {
   if (view === "list") {
     return (
-      <div className="flex flex-col gap-4 rounded-2xl border border-slate-700/40 bg-slate-800/50 p-4 shadow-sm shadow-slate-900/20 backdrop-blur-sm">
+      <div className="flex flex-col gap-4 rounded-2xl border border-border/40 bg-muted/60 p-4 shadow-sm shadow-foreground/10 backdrop-blur-sm">
         <div className="flex animate-pulse flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex flex-1 items-start gap-3 sm:items-center">
-            <div className="h-10 w-10 rounded-xl bg-slate-700/70 sm:h-12 sm:w-12" />
+            <div className="h-10 w-10 rounded-xl bg-muted/80 sm:h-12 sm:w-12" />
             <div className="flex flex-1 flex-col gap-2">
-              <div className="h-3 w-1/2 rounded-full bg-slate-700/70" />
-              <div className="h-3 w-1/3 rounded-full bg-slate-800/80" />
+              <div className="h-3 w-1/2 rounded-full bg-muted/80" />
+              <div className="h-3 w-1/3 rounded-full bg-muted/70" />
             </div>
           </div>
           <div className="flex w-full flex-wrap items-center gap-3 sm:w-auto sm:justify-end">
-            <div className="h-3 w-20 rounded-full bg-slate-800/70" />
-            <div className="h-3 w-16 rounded-full bg-slate-800/70" />
-            <div className="h-9 w-9 rounded-full bg-slate-800/70" />
+            <div className="h-3 w-20 rounded-full bg-muted/70" />
+            <div className="h-3 w-16 rounded-full bg-muted/70" />
+            <div className="h-9 w-9 rounded-full bg-muted/70" />
           </div>
         </div>
       </div>
@@ -28,11 +28,11 @@ const SkeletonCard: FC<SkeletonCardProps> = ({ view = "grid" }) => {
 
   return (
     <div className="group h-full animate-pulse">
-      <div className="h-full overflow-hidden rounded-2xl border border-slate-700/50 bg-slate-800/50 shadow-lg shadow-slate-900/20">
+      <div className="h-full overflow-hidden rounded-2xl border border-border/50 bg-muted/60 shadow-lg shadow-foreground/10">
         <div className="flex h-full flex-col items-center justify-center gap-4 px-4 py-6 text-center sm:px-6">
-          <div className="h-12 w-12 rounded-2xl bg-slate-700/70" />
-          <div className="h-3 w-3/4 rounded-full bg-slate-700/70" />
-          <div className="h-3 w-1/2 rounded-full bg-slate-800/80" />
+          <div className="h-12 w-12 rounded-2xl bg-muted/80" />
+          <div className="h-3 w-3/4 rounded-full bg-muted/80" />
+          <div className="h-3 w-1/2 rounded-full bg-muted/70" />
         </div>
       </div>
     </div>

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,0 +1,112 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react"
+
+export type ThemeMode = "light" | "dark"
+
+interface ThemeContextValue {
+  theme: ThemeMode
+  setTheme: (theme: ThemeMode) => void
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
+
+const STORAGE_KEY = "kdrive-theme"
+
+function getInitialTheme(): ThemeMode {
+  if (typeof window === "undefined") {
+    return "light"
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY) as ThemeMode | null
+  if (stored === "light" || stored === "dark") {
+    return stored
+  }
+
+  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches
+  return prefersDark ? "dark" : "light"
+}
+
+interface ThemeProviderProps {
+  children: ReactNode
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  const [theme, setThemeState] = useState<ThemeMode>(getInitialTheme)
+  const [hasManualPreference, setHasManualPreference] = useState(() => {
+    if (typeof window === "undefined") {
+      return false
+    }
+    return window.localStorage.getItem(STORAGE_KEY) !== null
+  })
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return
+    }
+
+    const root = document.documentElement
+    root.classList.toggle("dark", theme === "dark")
+    root.dataset.theme = theme
+    root.style.colorScheme = theme
+
+    if (typeof window !== "undefined") {
+      if (hasManualPreference) {
+        window.localStorage.setItem(STORAGE_KEY, theme)
+      } else {
+        window.localStorage.removeItem(STORAGE_KEY)
+      }
+    }
+  }, [theme, hasManualPreference])
+
+  useEffect(() => {
+    if (typeof window === "undefined" || hasManualPreference) {
+      return
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
+    const handleChange = (event: MediaQueryListEvent) => {
+      setThemeState(event.matches ? "dark" : "light")
+    }
+
+    mediaQuery.addEventListener("change", handleChange)
+    return () => mediaQuery.removeEventListener("change", handleChange)
+  }, [hasManualPreference])
+
+  const setTheme = useCallback((value: ThemeMode) => {
+    setHasManualPreference(true)
+    setThemeState(value)
+  }, [])
+
+  const toggleTheme = useCallback(() => {
+    setHasManualPreference(true)
+    setThemeState((current) => (current === "dark" ? "light" : "dark"))
+  }, [])
+
+  const value = useMemo(
+    () => ({
+      theme,
+      setTheme,
+      toggleTheme,
+    }),
+    [theme, setTheme, toggleTheme],
+  )
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext)
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider")
+  }
+
+  return context
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,14 +5,17 @@ import './index.css'
 import { AuthProvider } from './contexts/AuthContext'
 import { Toaster } from 'sonner'
 import { initPosthog } from './lib/posthog'
+import { ThemeProvider } from './contexts/ThemeContext'
 
 initPosthog()
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <AuthProvider>
-      <App />
-      <Toaster richColors />
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <App />
+        <Toaster richColors />
+      </AuthProvider>
+    </ThemeProvider>
   </React.StrictMode>,
 )

--- a/frontend/src/pages/DriveView.tsx
+++ b/frontend/src/pages/DriveView.tsx
@@ -162,7 +162,7 @@ export default function DriveView() {
   const skeletonCount = viewMode === "grid" ? 8 : 5
 
   return (
-    <div className="flex min-h-screen flex-col bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
+    <div className="flex min-h-screen flex-col bg-gradient-to-br from-background via-muted/30 to-background text-foreground">
       <Navbar
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
@@ -184,9 +184,9 @@ export default function DriveView() {
               ))}
             </div>
           ) : items.length === 0 ? (
-            <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-slate-700/60 bg-slate-800/40 px-4 py-12 text-center shadow-inner shadow-slate-900/40">
-              <FolderIcon className="mb-4 h-16 w-16 text-slate-600" />
-              <p className="text-base text-slate-400 sm:text-lg">
+            <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-border/60 bg-muted/40 px-4 py-12 text-center shadow-inner shadow-foreground/10">
+              <FolderIcon className="mb-4 h-16 w-16 text-muted-foreground" />
+              <p className="text-base text-muted-foreground sm:text-lg">
                 {searchQuery ? "No items match your search" : "This folder is empty"}
               </p>
             </div>
@@ -203,7 +203,7 @@ export default function DriveView() {
                   style={{ animationDelay: `${index * 50}ms` }}
                 >
                   {viewMode === "grid" ? (
-                    <Card className="group h-full overflow-hidden border border-slate-700/50 bg-slate-800/60 shadow-lg shadow-slate-900/20 transition-all duration-300 hover:-translate-y-1 hover:border-slate-600 hover:bg-slate-800/80">
+                    <Card className="group h-full overflow-hidden border border-border/60 bg-muted/60 shadow-lg shadow-foreground/10 transition-all duration-300 hover:-translate-y-1 hover:border-border hover:bg-muted/80">
                       <CardContent className="relative flex h-full flex-col items-center justify-center gap-4 px-4 py-6 text-center sm:px-6">
                         {item.type === "folder" ? (
                           <FolderCard
@@ -225,14 +225,14 @@ export default function DriveView() {
                               <Button
                                 variant="ghost"
                                 size="icon"
-                                className="absolute right-3 top-3 h-9 w-9 rounded-full text-slate-400 transition-colors duration-200 hover:bg-slate-700 hover:text-white"
+                                className="absolute right-3 top-3 h-9 w-9 rounded-full text-muted-foreground transition-colors duration-200 hover:bg-muted hover:text-foreground"
                               >
                                 <MoreVertical className="h-4 w-4" />
                               </Button>
                             </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end" className="w-40 rounded-xl border border-slate-700/60 bg-slate-800/95 text-slate-200 backdrop-blur">
+                            <DropdownMenuContent align="end" className="w-40 rounded-xl border border-border/60 bg-popover text-foreground backdrop-blur">
                               <DropdownMenuItem
-                                className="hover:bg-slate-700 focus:bg-slate-700"
+                                className="hover:bg-muted focus:bg-muted"
                                 onClick={() => {
                                   const name = window.prompt("Rename folder", item.name)
                                   if (name) renameFolder(item.id, name)
@@ -241,7 +241,7 @@ export default function DriveView() {
                                 Rename
                               </DropdownMenuItem>
                               <DropdownMenuItem
-                                className="text-red-400 hover:bg-red-900/20 focus:bg-red-900/20"
+                                className="text-destructive hover:bg-destructive/10 focus:bg-destructive/10"
                                 onClick={() => {
                                   if (window.confirm("Delete folder?")) deleteFolder(item.id)
                                 }}
@@ -254,7 +254,7 @@ export default function DriveView() {
                       </CardContent>
                     </Card>
                   ) : (
-                    <div className="flex flex-col gap-4 rounded-2xl border border-slate-700/40 bg-slate-800/60 p-4 shadow-sm shadow-slate-900/20 backdrop-blur-sm transition-colors duration-200 hover:border-slate-600 hover:bg-slate-800/80 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex flex-col gap-4 rounded-2xl border border-border/50 bg-muted/60 p-4 shadow-sm shadow-foreground/10 backdrop-blur-sm transition-colors duration-200 hover:border-border hover:bg-muted/80 sm:flex-row sm:items-center sm:justify-between">
                       <div className="flex flex-1 items-start gap-3 sm:items-center">
                         {item.type === "folder" ? (
                           <FolderCard
@@ -272,11 +272,11 @@ export default function DriveView() {
                         )}
                       </div>
                       {item.type === "file" && (
-                        <div className="flex flex-wrap items-center gap-3 text-sm text-slate-400 sm:justify-end">
-                          <span className="rounded-full bg-slate-900/60 px-3 py-1 text-xs font-medium text-slate-300 sm:bg-transparent sm:px-0 sm:py-0">
+                        <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground sm:justify-end">
+                          <span className="rounded-full bg-background/80 px-3 py-1 text-xs font-medium text-muted-foreground sm:bg-transparent sm:px-0 sm:py-0">
                             {new Date(item.createdAt).toLocaleDateString()}
                           </span>
-                          <span className="rounded-full bg-slate-900/60 px-3 py-1 text-xs font-medium text-slate-300 sm:bg-transparent sm:px-0 sm:py-0">
+                          <span className="rounded-full bg-background/80 px-3 py-1 text-xs font-medium text-muted-foreground sm:bg-transparent sm:px-0 sm:py-0">
                             {formatBytes(item.size)}
                           </span>
                           <DropdownMenu>
@@ -284,32 +284,32 @@ export default function DriveView() {
                               <Button
                                 variant="ghost"
                                 size="icon"
-                                className="h-9 w-9 rounded-full text-slate-400 transition-colors duration-200 hover:bg-slate-700 hover:text-white"
+                                className="h-9 w-9 rounded-full text-muted-foreground transition-colors duration-200 hover:bg-muted hover:text-foreground"
                               >
                                 <MoreVertical className="h-4 w-4" />
                               </Button>
                             </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end" className="w-44 rounded-xl border border-slate-700/60 bg-slate-800/95 text-slate-200 backdrop-blur">
-                              <DropdownMenuItem className="hover:bg-slate-700 focus:bg-slate-700">
+                            <DropdownMenuContent align="end" className="w-44 rounded-xl border border-border/60 bg-popover text-foreground backdrop-blur">
+                              <DropdownMenuItem className="hover:bg-muted focus:bg-muted">
                                 Open
                               </DropdownMenuItem>
-                              <DropdownMenuItem className="hover:bg-slate-700 focus:bg-slate-700">
+                              <DropdownMenuItem className="hover:bg-muted focus:bg-muted">
                                 Share
                               </DropdownMenuItem>
                               <DropdownMenuItem
-                                className="hover:bg-slate-700 focus:bg-slate-700"
+                                className="hover:bg-muted focus:bg-muted"
                                 onClick={() => handleDownload(item)}
                               >
                                 Download
                               </DropdownMenuItem>
                               <DropdownMenuItem
-                                className="hover:bg-slate-700 focus:bg-slate-700"
+                                className="hover:bg-muted focus:bg-muted"
                                 onClick={() => handleRename(item)}
                               >
                                 Rename
                               </DropdownMenuItem>
                               <DropdownMenuItem
-                                className="text-red-400 hover:bg-red-900/20 focus:bg-red-900/20"
+                                className="text-destructive hover:bg-destructive/10 focus:bg-destructive/10"
                                 onClick={() => handleDelete(item.id)}
                               >
                                 Delete
@@ -319,20 +319,20 @@ export default function DriveView() {
                         </div>
                       )}
                       {item.type === "folder" && (
-                        <div className="flex flex-wrap items-center gap-3 text-sm text-slate-400 sm:justify-end">
+                        <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground sm:justify-end">
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                               <Button
                                 variant="ghost"
                                 size="icon"
-                                className="h-9 w-9 rounded-full text-slate-400 transition-colors duration-200 hover:bg-slate-700 hover:text-white"
+                                className="h-9 w-9 rounded-full text-muted-foreground transition-colors duration-200 hover:bg-muted hover:text-foreground"
                               >
                                 <MoreVertical className="h-4 w-4" />
                               </Button>
                             </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end" className="w-40 rounded-xl border border-slate-700/60 bg-slate-800/95 text-slate-200 backdrop-blur">
+                            <DropdownMenuContent align="end" className="w-40 rounded-xl border border-border/60 bg-popover text-foreground backdrop-blur">
                               <DropdownMenuItem
-                                className="hover:bg-slate-700 focus:bg-slate-700"
+                                className="hover:bg-muted focus:bg-muted"
                                 onClick={() => {
                                   const name = window.prompt("Rename folder", item.name)
                                   if (name) renameFolder(item.id, name)
@@ -341,7 +341,7 @@ export default function DriveView() {
                                 Rename
                               </DropdownMenuItem>
                               <DropdownMenuItem
-                                className="text-red-400 hover:bg-red-900/20 focus:bg-red-900/20"
+                                className="text-destructive hover:bg-destructive/10 focus:bg-destructive/10"
                                 onClick={() => {
                                   if (window.confirm("Delete folder?")) deleteFolder(item.id)
                                 }}

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -56,20 +56,20 @@ export default function LandingPage() {
   ]
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
+    <div className="min-h-screen bg-gradient-to-br from-background via-muted/30 to-background text-foreground">
       {/* Navigation */}
-      <nav className="bg-slate-800/80 backdrop-blur-sm border-b border-slate-700/50 px-6 py-4">
-        <div className="max-w-7xl mx-auto flex items-center justify-between">
+      <nav className="border-b border-border/50 bg-card/80 px-6 py-4 backdrop-blur-sm">
+        <div className="mx-auto flex max-w-7xl items-center justify-between">
           <div className="flex items-center space-x-2">
-            <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center">
-              <Cloud className="w-5 h-5 text-white" />
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-blue-500 to-purple-600">
+              <Cloud className="h-5 w-5 text-white" />
             </div>
-            <span className="text-2xl font-bold text-white">KDrive</span>
+            <span className="text-2xl font-bold text-foreground">KDrive</span>
           </div>
           <div className="flex items-center space-x-4">
             <Button
               variant="outline"
-              className="bg-slate-700/50 border-slate-600 text-slate-300 hover:bg-slate-600 hover:text-white transition-all duration-200"
+              className="rounded-xl bg-card/60 text-foreground transition-colors duration-200 hover:bg-accent hover:text-accent-foreground"
               onClick={() => navigate('/signin')}
             >
               Sign In
@@ -82,13 +82,13 @@ export default function LandingPage() {
       <section className="px-6 py-20">
         <div className="max-w-7xl mx-auto text-center">
           <div className="animate-in fade-in slide-in-from-bottom-4 duration-1000">
-            <h1 className="text-5xl md:text-7xl font-bold text-white mb-6 tracking-tight">
+            <h1 className="mb-6 text-5xl font-bold tracking-tight text-foreground md:text-7xl">
               Your files,{" "}
               <span className="bg-gradient-to-r from-blue-400 via-purple-500 to-emerald-400 bg-clip-text text-transparent">
                 everywhere
               </span>
             </h1>
-            <p className="text-xl text-slate-300 mb-8 max-w-3xl mx-auto leading-relaxed">
+            <p className="mx-auto mb-8 max-w-3xl text-xl leading-relaxed text-muted-foreground">
               Store, sync, and share your files with the most elegant cloud storage solution. Experience seamless
               collaboration with enterprise-grade security.
             </p>
@@ -107,25 +107,25 @@ export default function LandingPage() {
                 className={`w-5 h-5 ml-2 transition-transform duration-200 ${isHovered ? "translate-x-1" : ""}`}
               />
             </Button>
-            <p className="text-slate-400 mt-4">No credit card required • 15GB free storage</p>
+            <p className="mt-4 text-muted-foreground">No credit card required • 15GB free storage</p>
           </div>
 
           {/* Hero Visual */}
           <div className="mt-16 animate-in fade-in slide-in-from-bottom-4 duration-1000 delay-400">
             <div className="relative max-w-4xl mx-auto">
-              <div className="bg-gradient-to-r from-slate-800/60 to-slate-700/60 backdrop-blur-sm rounded-2xl border border-slate-600/50 p-8 shadow-2xl">
+              <div className="rounded-2xl border border-border/60 bg-gradient-to-r from-card/70 to-card/60 p-8 shadow-2xl backdrop-blur-sm">
                 <div className="grid items-center justify-center grid-cols-3 gap-4 mb-6">
-                  <div className="flex items-center space-x-2 bg-slate-700/50 rounded-lg p-3 hover:bg-slate-600 transition-all duration-200">
+                  <div className="flex items-center space-x-2 rounded-lg bg-muted/60 p-3 transition-all duration-200 hover:bg-muted/80">
                     <Folder className="w-6 h-6 text-blue-400" />
-                    <span className="text-slate-200 font-medium">Documents</span>
+                    <span className="font-medium text-foreground">Documents</span>
                   </div>
-                  <div className="flex items-center space-x-2 bg-slate-700/50 rounded-lg p-3 hover:bg-slate-600 transition-all duration-200">
+                  <div className="flex items-center space-x-2 rounded-lg bg-muted/60 p-3 transition-all duration-200 hover:bg-muted/80">
                     <Upload className="w-6 h-6 text-emerald-400" />
-                    <span className="text-slate-200 font-medium">Upload</span>
+                    <span className="font-medium text-foreground">Upload</span>
                   </div>
-                  <div className="flex items-center space-x-2 bg-slate-700/50 rounded-lg p-3 hover:bg-slate-600 transition-all duration-200">
+                  <div className="flex items-center space-x-2 rounded-lg bg-muted/60 p-3 transition-all duration-200 hover:bg-muted/80">
                     <Share className="w-6 h-6 text-purple-400" />
-                    <span className="text-slate-200 font-medium">Share</span>
+                    <span className="font-medium text-foreground">Share</span>
                   </div>
                 </div>
               </div>
@@ -135,26 +135,26 @@ export default function LandingPage() {
       </section>
 
       {/* Features Section */}
-      <section className="px-6 py-20 bg-slate-800/30">
-        <div className="max-w-7xl mx-auto">
-          <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-white mb-4">Why choose KDrive?</h2>
-            <p className="text-xl text-slate-300 max-w-2xl mx-auto">
+      <section className="bg-muted/30 px-6 py-20">
+        <div className="mx-auto max-w-7xl">
+          <div className="mb-16 text-center">
+            <h2 className="mb-4 text-4xl font-bold text-foreground">Why choose KDrive?</h2>
+            <p className="mx-auto max-w-2xl text-xl text-muted-foreground">
               Built for modern teams who demand both beauty and functionality in their tools.
             </p>
           </div>
 
-          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+          <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-4">
             {features.map((feature, index) => (
               <Card
                 key={index}
-                className="h-64 flex items-center justify-center bg-slate-800/60 border-slate-700/50 hover:bg-slate-700/60 hover:border-slate-600 transition-all duration-300 transform hover:scale-105 animate-in fade-in slide-in-from-bottom-4 bg-center"
+                className="flex h-64 items-center justify-center border border-border/60 bg-card/70 transition-all duration-300 hover:-translate-y-1 hover:border-border hover:bg-card animate-in fade-in slide-in-from-bottom-4"
                 style={{ animationDelay: `${index * 100}ms` }}
               >
-                <CardContent className="flex flex-col items-center justify-center p-6 text-center w-full h-full">
-                  <div className="mb-4 flex justify-center items-center w-full">{feature.icon}</div>
-                  <h3 className="text-xl font-semibold text-white mb-2">{feature.title}</h3>
-                  <p className="text-slate-300 leading-relaxed">{feature.description}</p>
+                <CardContent className="flex h-full w-full flex-col items-center justify-center p-6 text-center">
+                  <div className="mb-4 flex w-full items-center justify-center">{feature.icon}</div>
+                  <h3 className="mb-2 text-xl font-semibold text-foreground">{feature.title}</h3>
+                  <p className="leading-relaxed text-muted-foreground">{feature.description}</p>
                 </CardContent>
               </Card>
             ))}
@@ -164,28 +164,28 @@ export default function LandingPage() {
 
       {/* Testimonials Section */}
       <section className="px-6 py-20">
-        <div className="max-w-7xl mx-auto">
-          <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-white mb-4">Loved by thousands</h2>
-            <p className="text-xl text-slate-300">See what our users have to say about KDrive.</p>
+        <div className="mx-auto max-w-7xl">
+          <div className="mb-16 text-center">
+            <h2 className="mb-4 text-4xl font-bold text-foreground">Loved by thousands</h2>
+            <p className="text-xl text-muted-foreground">See what our users have to say about KDrive.</p>
           </div>
-          <div className="grid md:grid-cols-3 gap-8">
+          <div className="grid gap-8 md:grid-cols-3">
             {testimonials.map((testimonial, index) => (
               <Card
                 key={index}
-                className="h-64 bg-slate-800/60 border-slate-700/50 hover:bg-slate-700/60 transition-all duration-300 animate-in fade-in slide-in-from-bottom-4"
+                className="h-64 border border-border/60 bg-card/70 transition-all duration-300 hover:-translate-y-1 hover:border-border hover:bg-card animate-in fade-in slide-in-from-bottom-4"
                 style={{ animationDelay: `${index * 150}ms` }}
               >
-                <CardContent className="flex flex-col items-center justify-center p-6 text-center w-full h-full">
-                  <div className="flex mb-4 justify-center items-center w-full">
+                <CardContent className="flex h-full w-full flex-col items-center justify-center p-6 text-center">
+                  <div className="mb-4 flex w-full items-center justify-center">
                     {[...Array(testimonial.rating)].map((_, i) => (
                       <Star key={i} className="w-5 h-5 text-yellow-400 fill-current" />
                     ))}
                   </div>
-                  <p className="text-slate-300 mb-4 italic">"{testimonial.content}"</p>
+                  <p className="mb-4 italic text-muted-foreground">"{testimonial.content}"</p>
                   <div>
-                    <p className="text-white font-semibold">{testimonial.name}</p>
-                    <p className="text-slate-400 text-sm">{testimonial.role}</p>
+                    <p className="font-semibold text-foreground">{testimonial.name}</p>
+                    <p className="text-sm text-muted-foreground">{testimonial.role}</p>
                   </div>
                 </CardContent>
               </Card>
@@ -195,10 +195,10 @@ export default function LandingPage() {
       </section>
 
       {/* CTA Section */}
-      <section className="px-6 py-20 bg-gradient-to-r from-blue-900/20 to-purple-900/20">
-        <div className="max-w-4xl mx-auto text-center">
-          <h2 className="text-4xl font-bold text-white mb-4">Ready to get started?</h2>
-          <p className="text-xl text-slate-300 mb-8">
+      <section className="bg-gradient-to-r from-primary/20 to-accent/20 px-6 py-20">
+        <div className="mx-auto max-w-4xl text-center">
+          <h2 className="mb-4 text-4xl font-bold text-foreground">Ready to get started?</h2>
+          <p className="mb-8 text-xl text-muted-foreground">
             Join thousands of users who trust KDrive with their most important files.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
@@ -212,7 +212,7 @@ export default function LandingPage() {
             <Button
               size="lg"
               variant="outline"
-              className="bg-slate-700/50 border-slate-600 text-slate-300 hover:bg-slate-600 hover:text-white px-8 py-4 text-lg font-semibold transition-all duration-300"
+              className="rounded-xl bg-card/60 text-foreground transition-all duration-300 hover:bg-accent hover:text-accent-foreground px-8 py-4 text-lg font-semibold"
             >
               View Pricing
             </Button>
@@ -221,23 +221,23 @@ export default function LandingPage() {
       </section>
 
       {/* Footer */}
-      <footer className="bg-slate-900/80 border-t border-slate-700/50 px-6 py-12">
-        <div className="max-w-7xl mx-auto">
-          <div className="flex flex-col md:flex-row justify-between items-center">
-            <div className="flex items-center space-x-2 mb-4 md:mb-0">
-              <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center">
-                <Cloud className="w-5 h-5 text-white" />
+      <footer className="border-t border-border/60 bg-card/80 px-6 py-12">
+        <div className="mx-auto max-w-7xl">
+          <div className="flex flex-col items-center justify-between gap-6 md:flex-row">
+            <div className="flex items-center space-x-2 md:mb-0">
+              <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-blue-500 to-purple-600">
+                <Cloud className="h-5 w-5 text-white" />
               </div>
-              <span className="text-2xl font-bold text-white">KDrive</span>
+              <span className="text-2xl font-bold text-foreground">KDrive</span>
             </div>
-            <div className="flex items-center space-x-6 text-slate-400">
-              <a href="#" className="hover:text-white transition-colors duration-200">
+            <div className="flex items-center space-x-6 text-muted-foreground">
+              <a href="#" className="transition-colors duration-200 hover:text-foreground">
                 Privacy
               </a>
-              <a href="#" className="hover:text-white transition-colors duration-200">
+              <a href="#" className="transition-colors duration-200 hover:text-foreground">
                 Terms
               </a>
-              <a href="#" className="hover:text-white transition-colors duration-200">
+              <a href="#" className="transition-colors duration-200 hover:text-foreground">
                 Support
               </a>
               <span>© 2024 KDrive. All rights reserved.</span>

--- a/frontend/src/pages/SignIn.tsx
+++ b/frontend/src/pages/SignIn.tsx
@@ -53,35 +53,35 @@ export default function SignInPage() {
 
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex items-center justify-center p-4">
+    <div className="relative flex min-h-screen items-center justify-center bg-gradient-to-br from-background via-muted/30 to-background p-4 text-foreground">
       {/* Background decoration */}
-      <div className="absolute inset-0 overflow-hidden">
-        <div className="absolute -top-40 -right-40 w-80 h-80 bg-blue-500/10 rounded-full blur-3xl"></div>
-        <div className="absolute -bottom-40 -left-40 w-80 h-80 bg-purple-500/10 rounded-full blur-3xl"></div>
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute -top-40 -right-40 h-80 w-80 rounded-full bg-blue-500/10 blur-3xl" />
+        <div className="absolute -bottom-40 -left-40 h-80 w-80 rounded-full bg-purple-500/10 blur-3xl" />
       </div>
 
       <div className="relative w-full max-w-md">
         {/* Back to home button */}
         <Button
           variant="ghost"
-          className="mb-6 text-slate-400 hover:text-white hover:bg-slate-800 transition-all duration-200"
+          className="mb-6 text-muted-foreground transition-all duration-200 hover:bg-muted hover:text-foreground"
           onClick={() => navigate("/")}
         >
           <ArrowLeft className="w-4 h-4 mr-2" />
           Back to Home
         </Button>
 
-        <Card className="bg-slate-800/80 backdrop-blur-sm border-slate-700/50 shadow-2xl">
-          <CardHeader className="text-center pb-6">
-            <div className="flex justify-center mb-4">
-              <div className="w-12 h-12 bg-gradient-to-br from-blue-500 to-purple-600 rounded-xl flex items-center justify-center">
-                <Cloud className="w-7 h-7 text-white" />
+        <Card className="border border-border/60 bg-card/80 shadow-2xl backdrop-blur-sm">
+          <CardHeader className="pb-6 text-center">
+            <div className="mb-4 flex justify-center">
+              <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-purple-600">
+                <Cloud className="h-7 w-7 text-white" />
               </div>
             </div>
-            <CardTitle className="text-2xl font-bold text-white">
+            <CardTitle className="text-2xl font-bold text-foreground">
               {isSignUp ? "Create your account" : "Welcome back"}
             </CardTitle>
-            <p className="text-slate-400 mt-2">
+            <p className="mt-2 text-muted-foreground">
               {isSignUp ? "Sign up to start using KDrive" : "Sign in to access your files"}
             </p>
           </CardHeader>
@@ -91,7 +91,7 @@ export default function SignInPage() {
             <form onSubmit={handleSubmit} className="space-y-4">
               {isSignUp && (
                 <div className="space-y-2">
-                  <Label htmlFor="name" className="text-slate-300">
+                  <Label htmlFor="name" className="text-sm font-medium text-foreground">
                     Full Name
                   </Label>
                   <Input
@@ -100,14 +100,14 @@ export default function SignInPage() {
                     placeholder="Enter your full name"
                     value={name}
                     onChange={(e) => setName(e.target.value)}
-                    className="bg-slate-700/50 border-slate-600 text-white placeholder:text-slate-400 focus:bg-slate-700 focus:border-slate-500 transition-all duration-200"
+                    className="bg-card/70 text-foreground placeholder:text-muted-foreground transition-all duration-200 focus:bg-background"
                     required={isSignUp}
                   />
                 </div>
               )}
 
               <div className="space-y-2">
-                <Label htmlFor="email" className="text-slate-300">
+                <Label htmlFor="email" className="text-sm font-medium text-foreground">
                   Email
                 </Label>
                 <Input
@@ -116,13 +116,13 @@ export default function SignInPage() {
                   placeholder="Enter your email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
-                  className="bg-slate-700/50 border-slate-600 text-white placeholder:text-slate-400 focus:bg-slate-700 focus:border-slate-500 transition-all duration-200"
+                  className="bg-card/70 text-foreground placeholder:text-muted-foreground transition-all duration-200 focus:bg-background"
                   required
                 />
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="password" className="text-slate-300">
+                <Label htmlFor="password" className="text-sm font-medium text-foreground">
                   Password
                 </Label>
                 <div className="relative">
@@ -132,14 +132,14 @@ export default function SignInPage() {
                     placeholder="Enter your password"
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
-                    className="bg-slate-700/50 border-slate-600 text-white placeholder:text-slate-400 focus:bg-slate-700 focus:border-slate-500 transition-all duration-200 pr-10"
+                    className="pr-10 bg-card/70 text-foreground placeholder:text-muted-foreground transition-all duration-200 focus:bg-background"
                     required
                   />
                   <Button
                     type="button"
                     variant="ghost"
                     size="icon"
-                    className="absolute right-0 top-0 h-full px-3 text-slate-400 hover:text-white"
+                    className="absolute right-0 top-0 h-full px-3 text-muted-foreground hover:text-foreground"
                     onClick={() => setShowPassword(!showPassword)}
                   >
                     {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
@@ -166,8 +166,8 @@ export default function SignInPage() {
             </form>
 
             {/* Toggle Sign Up/Sign In */}
-            <div className="text-center pt-4 border-t border-slate-700">
-              <p className="text-slate-400">
+            <div className="border-t border-border/60 pt-4 text-center">
+              <p className="text-muted-foreground">
                 {isSignUp ? "Already have an account?" : "Don't have an account?"}{" "}
                 <Button
                   variant="link"
@@ -182,14 +182,14 @@ export default function SignInPage() {
         </Card>
 
         {/* Footer */}
-        <div className="text-center mt-8 text-slate-400 text-sm">
+        <div className="mt-8 text-center text-sm text-muted-foreground">
           <p>
             By continuing, you agree to our{" "}
-            <a href="#" className="text-blue-400 hover:text-blue-300 transition-colors duration-200">
+            <a href="#" className="text-primary hover:text-primary/80 transition-colors duration-200">
               Terms of Service
             </a>{" "}
             and{" "}
-            <a href="#" className="text-blue-400 hover:text-blue-300 transition-colors duration-200">
+            <a href="#" className="text-primary hover:text-primary/80 transition-colors duration-200">
               Privacy Policy
             </a>
           </p>


### PR DESCRIPTION
## Summary
- add a reusable ThemeContext that syncs the light/dark mode with the document element and local storage
- wrap the app with the theme provider and expose a toggle control from the navbar
- replace hard-coded slate colors across shared components and pages with CSS variable powered tailwind tokens

## Testing
- yarn test --run *(fails: requires dependencies to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c8bf81df4c8331a6f7a6be414cb147