### PR TITLE
Add create folder dialog and integrate with drive view

### DIFF
--- a/frontend/src/components/CreateFolderDialog.tsx
+++ b/frontend/src/components/CreateFolderDialog.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useRef } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+import { toast } from "sonner"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+const folderSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "Folder name is required")
+    .max(128, "Folder name must be under 128 characters"),
+})
+
+export type CreateFolderFormValues = z.infer<typeof folderSchema>
+
+export interface CreateFolderDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  parentId: number
+  authToken?: string | null
+  onCreated?: () => Promise<void> | void
+}
+
+export function CreateFolderDialog({
+  open,
+  onOpenChange,
+  parentId,
+  authToken,
+  onCreated,
+}: CreateFolderDialogProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<CreateFolderFormValues>({
+    resolver: zodResolver(folderSchema),
+    defaultValues: { name: "" },
+  })
+
+  const nameField = register("name")
+
+  useEffect(() => {
+    if (open) {
+      const timer = window.setTimeout(() => {
+        inputRef.current?.focus()
+      }, 50)
+      return () => window.clearTimeout(timer)
+    }
+  }, [open])
+
+  const handleDialogChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      reset({ name: "" })
+    }
+    onOpenChange(nextOpen)
+  }
+
+  const onSubmit = handleSubmit(async (values) => {
+    if (!authToken) {
+      toast.error("You must be signed in to create folders")
+      return
+    }
+
+    try {
+      const response = await fetch("/api/folders", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({
+          name: values.name,
+          parentId: parentId === 0 ? null : parentId,
+        }),
+      })
+
+      if (!response.ok) {
+        const errorData = (await response
+          .json()
+          .catch(() => null)) as { message?: string; error?: string } | null
+        const message =
+          (errorData && (errorData.message || errorData.error)) ||
+          "Failed to create folder"
+        throw new Error(message)
+      }
+
+      toast.success("Folder created")
+      await onCreated?.()
+      handleDialogChange(false)
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to create folder"
+      toast.error(message)
+    }
+  })
+
+  return (
+    <Dialog open={open} onOpenChange={handleDialogChange}>
+      <DialogContent>
+        <form onSubmit={onSubmit} className="space-y-4">
+          <DialogHeader>
+            <DialogTitle>Create new folder</DialogTitle>
+            <DialogDescription>
+              Organize your files by creating a new folder in this location.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-2">
+            <Label htmlFor="folder-name">Folder name</Label>
+            <Input
+              id="folder-name"
+              placeholder="Enter a folder name"
+              {...nameField}
+              ref={(element) => {
+                nameField.ref(element)
+                inputRef.current = element
+              }}
+              aria-invalid={errors.name ? "true" : "false"}
+            />
+            {errors.name ? (
+              <p className="text-sm text-destructive">{errors.name.message}</p>
+            ) : null}
+          </div>
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" variant="outline" disabled={isSubmitting}>
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Creating…" : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+const DialogTrigger = DialogPrimitive.Trigger
+const DialogPortal = DialogPrimitive.Portal
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in",
+      className,
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-6 border border-border/60 bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "sm:rounded-2xl sm:border shadow-foreground/10",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className,
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/frontend/src/pages/DriveView.tsx
+++ b/frontend/src/pages/DriveView.tsx
@@ -20,6 +20,7 @@ import {
 import { Folder as FolderIcon, MoreVertical } from "lucide-react"
 import { useAuth } from "@/hooks/useAuth"
 import { supabaseClient } from "@/contexts/SupabaseContext"
+import { CreateFolderDialog } from "@/components/CreateFolderDialog"
 
 function formatBytes(bytes: number) {
   if (bytes === 0) return "0 B"
@@ -55,6 +56,7 @@ export default function DriveView() {
     { id: null, name: "My Drive" },
   ])
   const [isContentVisible, setIsContentVisible] = useState(false)
+  const [isCreateFolderOpen, setIsCreateFolderOpen] = useState(false)
 
   const isLoading = foldersLoading || filesLoading
 
@@ -95,23 +97,7 @@ export default function DriveView() {
 
   const token = session?.access_token
 
-  const handleCreateFolder = async () => {
-    if (!token) return
-    const name = window.prompt("Folder name")
-    if (!name) return
-    await fetch("/api/folders", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify({
-        name,
-        parentId: currentFolderId === 0 ? null : currentFolderId,
-      }),
-    })
-    refetchFolders()
-  }
+  const handleCreateFolder = () => setIsCreateFolderOpen(true)
 
   const handleDelete = async (id: number) => {
     if (!token) return
@@ -360,6 +346,14 @@ export default function DriveView() {
           )}
         </div>
       </main>
+
+      <CreateFolderDialog
+        open={isCreateFolderOpen}
+        onOpenChange={setIsCreateFolderOpen}
+        parentId={currentFolderId}
+        authToken={token}
+        onCreated={refetchFolders}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add Radix dialog primitives with Shadcn styling helpers
- build a reusable CreateFolderDialog with validation, focus handling, and toast feedback
- wire the dialog into DriveView so the New Folder action opens it and refreshes folders on success

## Testing
- yarn test *(fails: Yarn workspace expects install; command suggests running `yarn install` to update lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68c8c61caa008331b093251bb33a22a7